### PR TITLE
Update Salesforce API Version

### DIFF
--- a/lib/databasedotcom/client.rb
+++ b/lib/databasedotcom/client.rb
@@ -127,7 +127,7 @@ module Databasedotcom
         end
       end
 
-      self.version = "22.0" unless self.version
+      self.version = "31.0" unless self.version
 
       self.oauth_token
     end

--- a/lib/databasedotcom/version.rb
+++ b/lib/databasedotcom/version.rb
@@ -1,5 +1,5 @@
 # <b>DEPRECATED:</b> Please use <tt>restforce</tt> (https://github.com/ejholmes/restforce) instead.
 warn "DEPRECATED: Please use restforce (https://github.com/ejholmes/restforce) instead."
 module Databasedotcom
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -169,10 +169,10 @@ describe Databasedotcom::Client do
         @client.authenticate(:username => "username", :password => "password")
       end
 
-      it "defaults to version 22.0" do
+      it "defaults to version 31.0" do
         @client.version = nil
         @client.authenticate(:username => "username", :password => "password")
-        @client.version.should == "22.0"
+        @client.version.should == "31.0"
       end
 
     end


### PR DESCRIPTION
Salesforce is retiring APIs this year and next year ([link](https://help.salesforce.com/s/articleView?id=000351312&type=1)), so we're preemptively updating this legacy gem to the earliest version that continues to be supported.

* Versions 7.0 through 20.0: Retiring June 1, 2022
* Versions 21.0 through 30.0: Retiring June 1, 2023